### PR TITLE
Add Python 3.12 support and configure Codecov token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
     steps:
       - name: Check out
@@ -69,6 +69,8 @@ jobs:
       - name: Upload coverage reports to Codecov with GitHub Action on Python 3.11
         uses: codecov/codecov-action@v3
         if: ${{ matrix.python-version == '3.11' }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   check-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -6,27 +6,6 @@ on:
     branches: [main]
 
 jobs:
-  publish:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out
-        uses: actions/checkout@v3
-
-      - name: Set up the environment
-        uses: ./.github/actions/setup-poetry-env
-
-      - name: Export tag
-        id: vars
-        run: echo tag=${GITHUB_REF#refs/*/} >> $GITHUB_OUTPUT
-
-      - name: Build and publish
-        run: |
-          poetry version $RELEASE_VERSION
-          just build-and-publish
-        env:
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-          RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
-
   deploy-docs:
     runs-on: ubuntu-latest
     needs: publish

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [testenv]
 passenv = PYTHON_VERSION


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Documentation in `docs` is updated
- [x] The projection version has been bumped using the [poetry version](https://python-poetry.org/docs/cli/#version) command, providing an appropriate [SemVer](https://semver.org/) version upgrade.

**Description of changes**

- Disable publish to PyPI in GitHub action
- Added python 3.12 to the set of python environments the tests run on
- Updated codecov config
